### PR TITLE
Hard coding the repo we want to call

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 curl --header "Content-Type: application/json" \
   --request POST \
   --data '{"event":"entry.create","created_at":"2020-01-10T08:47:36.649Z","model":"example","entry":{}}' \
-  "http://localhost:5000/api?event_type=strapi_updated&repo={OWNER}/{NAME}"
+  "http://localhost:5000/api?event_type=strapi_updated"
 ```
 
 ## Build, Run, Publish Docker Image

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ on:
 4 - Create a new Webhook in Strapi that points to the service with the following query params:
 
 - `event_type`: Any string. This value must match the `repository_dispatch` type specified in your GitHub Actions workflow file.
-- `repo`: GitHub `username/repo`
 
 For example:
 

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -6,15 +6,12 @@ apiRoute.post(
   '/',
   async (
     req: Request<null, ResponseBody, RequestBody, QueryParams>,
-    res: Response<ResponseBody>
+    res: Response<ResponseBody>,
   ) => {
-    const { event_type: eventType, repo } = req.query;
+    const { event_type: eventType } = req.query;
     try {
       if (!eventType) {
         throw new Error('event_type param missing');
-      }
-      if (!repo) {
-        throw new Error('repo param missing');
       }
     } catch (e: any) {
       return res.status(400).send(e.message);
@@ -22,7 +19,7 @@ apiRoute.post(
 
     try {
       const response = await fetch(
-        `https://api.github.com/repos/${repo}/dispatches`,
+        `https://api.github.com/repos/estuary/marketing-site/dispatches`,
         {
           method: 'post',
           headers: new Headers({
@@ -34,7 +31,7 @@ apiRoute.post(
             event_type: eventType,
             client_payload: req.body,
           }),
-        }
+        },
       );
       if (!response.ok) {
         throw new Error(response.statusText);
@@ -45,5 +42,5 @@ apiRoute.post(
       console.error(`${msg}:`, e.message);
       res.status(500).send(msg);
     }
-  }
+  },
 );

--- a/src/routes/api/types.ts
+++ b/src/routes/api/types.ts
@@ -2,7 +2,6 @@ export type ResponseBody = string;
 
 export type QueryParams = {
   event_type: string;
-  repo: string;
 };
 
 export enum EventType {


### PR DESCRIPTION
We ONLY use this for our marketing site so we can just hard code the repo we want to be called.

Should take care of : https://github.com/estuary/strapi-webhook-actions-proxy/security/code-scanning/1