### PR TITLE
Fixes problem with github action permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,9 @@ jobs:
   build-and-deploy:
     name: Build, Push & Deploy
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write' # Required to request the OIDC token
     needs: lint
     steps:
       - name: Checkout


### PR DESCRIPTION
Never seen the issue we had with this workflow- apparently sometimes we need to explicitly define the permissions?

It's also possible that because this is a fork, we're simply not allowed to do this with it, github documentation is unclear